### PR TITLE
Initial ASVS-Cheatsheet-Rules Mapping

### DIFF
--- a/cheatsheet-asvs-mapping.md
+++ b/cheatsheet-asvs-mapping.md
@@ -65,6 +65,26 @@
 - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
 
 
+## Rules Recommend Solution
+
+###### V4.2 Operation Level Access Control
+- https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html
+
+
+###### V5.3 Output encoding and Injection Prevention Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+
+
+###### V7.1 Log Content Requirements
+###### V7.2 Log Processing Requirements
+###### V7.3 Log Protection Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+
+
+###### V12.1 File Upload Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+
+
 ## Rules Org/Team/Technology Stack Dependent:
 
 ###### V1.7 Errors, Logging and Auditing Architectural Requirements
@@ -134,23 +154,4 @@
 ###### V14.4 HTTP Security Headers Requirements
 - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
 
-
-## Rules Recommend Solution
-
-###### V4.2 Operation Level Access Control
-- https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html
-
-
-###### V5.3 Output encoding and Injection Prevention Requirements
-- https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
-
-
-###### V7.1 Log Content Requirements
-###### V7.2 Log Processing Requirements
-###### V7.3 Log Protection Requirements
-- https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
-
-
-###### V12.1 File Upload Requirements
-- https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
 

--- a/cheatsheet-asvs-mapping.md
+++ b/cheatsheet-asvs-mapping.md
@@ -97,7 +97,7 @@ Rules which can also have a secure wrapper/library that can be recommended to us
 
 
 ## Rules Org/Team/Technology Stack Dependent:
-
+This is a little tricker, as rules are possible but very much dependent on the security team/org approach. Perhaps this would be more of a community effort and secure patterns that have already found success.
 ###### V1.7 Errors, Logging and Auditing Architectural Requirements
 - https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
 

--- a/cheatsheet-asvs-mapping.md
+++ b/cheatsheet-asvs-mapping.md
@@ -73,6 +73,17 @@
 
 ###### V5.3 Output encoding and Injection Prevention Requirements
 - https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_in_Java_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+
 
 
 ###### V7.1 Log Content Requirements

--- a/cheatsheet-asvs-mapping.md
+++ b/cheatsheet-asvs-mapping.md
@@ -66,7 +66,7 @@
 
 
 ## Rules Recommend Solution
-
+Rules which can also have a secure wrapper/library that can be recommended to use e.g. DOMPurify.
 ###### V4.2 Operation Level Access Control
 - https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html
 
@@ -164,5 +164,4 @@
 
 ###### V14.4 HTTP Security Headers Requirements
 - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
-
 

--- a/cheatsheet-asvs-mapping.md
+++ b/cheatsheet-asvs-mapping.md
@@ -65,7 +65,7 @@
 - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
 
 
-## Rules Org/Team/Technology-stack Dependent:
+## Rules Org/Team/Technology Stack Dependent:
 
 ###### V1.7 Errors, Logging and Auditing Architectural Requirements
 - https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
@@ -101,7 +101,7 @@
 - https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
 
 
-###### V5.3 Output encoding and Injection Precention Requirements
+###### V5.3 Output encoding and Injection Prevention Requirements
 - https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html
 - https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html
 
@@ -135,7 +135,7 @@
 - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
 
 
-## Rules Reccomend Solution
+## Rules Recommend Solution
 
 ###### V4.2 Operation Level Access Control
 - https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html

--- a/cheatsheet-asvs-mapping.md
+++ b/cheatsheet-asvs-mapping.md
@@ -1,5 +1,5 @@
 ## Rules Possible:
-
+These are rules which can be directly linked to secure code snippets within the Cheat Sheets. Rules should be relatively easier to write and should be tackled first.
 ###### V3.4 Cookie-based Session Management
 - https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
 
@@ -164,4 +164,3 @@ Rules which can also have a secure wrapper/library that can be recommended to us
 
 ###### V14.4 HTTP Security Headers Requirements
 - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
-

--- a/cheatsheet-asvs-mapping.md
+++ b/cheatsheet-asvs-mapping.md
@@ -1,0 +1,156 @@
+## Rules Possible:
+
+###### V3.4 Cookie-based Session Management
+- https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+
+	
+###### V3.5 Token-based Session Management
+- https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html
+
+
+###### V4.2 Operation Level Access Control
+- https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+
+
+###### V5: Validation, Sanitization and Encoding Verification Requirements:
+- https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html
+
+
+###### V5.2 Sanitization and Sandboxing Requirements:
+- https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+
+
+###### V5.3 Output encoding and Injection Prevention Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_in_Java_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+
+
+###### V5.5 Deserialization Prevention Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+
+
+###### V7.4 Error Handling
+- https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html
+
+
+###### V9.1 Communications Security Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html
+
+
+###### V10.1 Code Integrity Controls
+- https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html
+
+
+###### V12.6 SSRF Protection Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+
+
+###### V14.3 Unintended Security Disclosure Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html
+
+
+###### V14.4 HTTP Security Headers Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
+
+
+## Rules Org/Team/Technology-stack Dependent:
+
+###### V1.7 Errors, Logging and Auditing Architectural Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+
+
+###### V1.11 Business Logic Architectural Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Abuse_Case_Cheat_Sheet.html
+
+
+###### V1.13 API Architectural Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
+
+
+###### V3.5 Token-based Session Management
+- https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
+
+
+###### V3.7 Defenses Against Session Management Exploits
+- https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Transaction_Authorization_Cheat_Sheet.html
+
+
+###### V4.1 General Access Control Design
+- https://cheatsheetseries.owasp.org/cheatsheets/Access_Control_Cheat_Sheet.html
+
+
+###### V5: Validation, Sanitization and Encoding Verification Requirements:
+- https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Bean_Validation_Cheat_Sheet.html
+
+
+###### V5.2 Sanitization and Sandboxing Requirements:
+- https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+
+
+###### V5.3 Output encoding and Injection Precention Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html
+
+
+###### V6.2 Algorithms
+- https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Key_Management_Cheat_Sheet.html
+
+
+###### V6.4 Secret Management
+- https://cheatsheetseries.owasp.org/cheatsheets/Key_Management_Cheat_Sheet.html
+
+
+###### V7.1 Log Content Requirements
+###### V7.2 Log Processing Requirements
+###### V7.3 Log Protection Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+
+
+###### V12.6 SSRF Protection Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+
+
+###### V13.2 RESTful Web Service Verification Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/REST_Assessment_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html
+- https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+
+
+###### V14.4 HTTP Security Headers Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
+
+
+## Rules Reccomend Solution
+
+###### V4.2 Operation Level Access Control
+- https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html
+
+
+###### V5.3 Output encoding and Injection Prevention Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+
+
+###### V7.1 Log Content Requirements
+###### V7.2 Log Processing Requirements
+###### V7.3 Log Protection Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+
+
+###### V12.1 File Upload Requirements
+- https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html
+


### PR DESCRIPTION
An initial once over of mapping ASVS to Cheatsheet series to possible rules. I've split the rules into:

**Rules Possible**
These are rules which can be directly linked to secure code snippets within the Cheat Sheets. Rules should be relatively easier to write and should be tackled first.

**Rules Recommend Solution**
Rules which can also have a secure wrapper/library that can be recommended to use e.g. DOMPurify.

**Rules Org/Team/Technology Stack Dependent**
This is a little tricker, as rules are possible but very much dependent on the security team/org approach. Perhaps this would be more of a community effort and secure patterns that have already found success.

